### PR TITLE
Fix PropertyFileReader to handle CR LF line endings

### DIFF
--- a/src/main/java/de/poiu/apron/io/PropertyFileReader.java
+++ b/src/main/java/de/poiu/apron/io/PropertyFileReader.java
@@ -209,7 +209,18 @@ public class PropertyFileReader implements Closeable {
         break;
       }
 
-      escaped = c == '\\' && !escaped;
+      if (c == '\r' && escaped) {
+        // check for \r\n sequence - in that case, both should be escaped, keep escaped flag on
+        reader.mark(1);
+        final int nextCInt= reader.read();
+        // not the \r\n case
+        if (nextCInt != '\n') {
+          escaped = false;
+        }
+        reader.reset();
+      } else {
+        escaped = c == '\\' && !escaped;
+      }
     }
 
     return sb;

--- a/src/test/java/de/poiu/apron/PropertyFileTest.java
+++ b/src/test/java/de/poiu/apron/PropertyFileTest.java
@@ -18,6 +18,8 @@ package de.poiu.apron;
 import de.poiu.apron.entry.BasicEntry;
 import de.poiu.apron.entry.Entry;
 import de.poiu.apron.entry.PropertyEntry;
+import org.junit.Test;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -33,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import org.junit.Test;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -54,9 +55,9 @@ public class PropertyFileTest {
       + "keyA1=valueA1\n"
       + " keyA2  =  valueA2\n"
       + "\tkeyA3\t=\tvalue A3\t\n"
-      + "keyA4 = very long\\\r\n"
-      + "value A4 over \\\r\n"
-      + "multiple lines\r\n"
+      + "keyA4 = very long\\\n"
+      + "value A4 over \\\n"
+      + "multiple lines\n"
       + "        \n"
       + "keyB1:valueB1\n"
       + " keyB2 : valueB2\n"
@@ -157,7 +158,7 @@ public class PropertyFileTest {
     // - preparation
     final File propertyFile= this.createTestFile(""
       + "   keyA1 =  my very \t \\\n"
-      + "   long value that \\\r\n"
+      + "   long value that \\\n"
       + "   \tspans several lines = \\\n"
       + " and contains = characters \t \n"
       + "keyA2 = some simple value \t ");
@@ -1938,9 +1939,6 @@ public class PropertyFileTest {
     assertThat(propertyFile.get(key1)).isEqualTo(value1);
     assertThat(propertyFile.get(key2)).isEqualTo(value2);
   }
-
-
-
 
   private File createTestFile(final String content) {
     return createTestFile(content, Charset.forName("UTF-8"));

--- a/src/test/java/de/poiu/apron/PropertyFileTest.java
+++ b/src/test/java/de/poiu/apron/PropertyFileTest.java
@@ -54,9 +54,9 @@ public class PropertyFileTest {
       + "keyA1=valueA1\n"
       + " keyA2  =  valueA2\n"
       + "\tkeyA3\t=\tvalue A3\t\n"
-      + "keyA4 = very long\\\n"
-      + "value A4 over \\\n"
-      + "multiple lines\n"
+      + "keyA4 = very long\\\r\n"
+      + "value A4 over \\\r\n"
+      + "multiple lines\r\n"
       + "        \n"
       + "keyB1:valueB1\n"
       + " keyB2 : valueB2\n"
@@ -157,7 +157,7 @@ public class PropertyFileTest {
     // - preparation
     final File propertyFile= this.createTestFile(""
       + "   keyA1 =  my very \t \\\n"
-      + "   long value that \\\n"
+      + "   long value that \\\r\n"
       + "   \tspans several lines = \\\n"
       + " and contains = characters \t \n"
       + "keyA2 = some simple value \t ");

--- a/src/test/java/de/poiu/apron/PropertyFileTest.java
+++ b/src/test/java/de/poiu/apron/PropertyFileTest.java
@@ -18,8 +18,6 @@ package de.poiu.apron;
 import de.poiu.apron.entry.BasicEntry;
 import de.poiu.apron.entry.Entry;
 import de.poiu.apron.entry.PropertyEntry;
-import org.junit.Test;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -35,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import org.junit.Test;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -1939,6 +1938,9 @@ public class PropertyFileTest {
     assertThat(propertyFile.get(key1)).isEqualTo(value1);
     assertThat(propertyFile.get(key2)).isEqualTo(value2);
   }
+
+
+
 
   private File createTestFile(final String content) {
     return createTestFile(content, Charset.forName("UTF-8"));

--- a/src/test/java/de/poiu/apron/io/PropertyFileReaderTest.java
+++ b/src/test/java/de/poiu/apron/io/PropertyFileReaderTest.java
@@ -433,38 +433,32 @@ public class PropertyFileReaderTest {
   public void test_CrLfEndings() throws IOException {
     // - preparation
     final File propertyFile= this.createTestFile(""
-        + "keyA1=valueA1\n"
-        + " keyA2  =  valueA2\n"
-        + "\tkeyA3\t=\tvalue A3\t\n"
-        + "keyA4 = very long\\\r\n"
-        + "value A4 over \\\r\n"
-        + "multiple lines\r\n"
-        + "        \n"
-        + "keyB1:valueB1\n"
-        + " keyB2 : valueB2\n"
-        + "\t keyB3\t:\t value B3 \n"
-        + "keyB4 : very long\\\n"
-        + "value B4 over \\\n"
-        + "multiple lines\\\n"
-        + "\n"
-        + "keyC1 valueC1\n"
-        + "  keyC2   valueC2\n"
-        + "\t keyC3\t\tvalue C3 \n"
-        + "keyC4   very long\\\n"
-        + "value C4 over \\\n"
-        + "\t \tmultiple lines");
+      + "lf                       = One\\\nTwo\n"
+      + "cr                       = One\\\rTwo\r"
+      + "crlf_both_escaped        = One\\\r\\\nTwo\r\n"
+      + "crlf_only_first_escaped  = One\\\r\nTwo\r\n");
+    // assert our assumptions about the java.util.Properties implementation
+    assertThat(javaUtilProperties.size()).as("Check assumption about java.util.Properties size").isEqualTo(4);
+    assertThat(javaUtilProperties.containsKey("lf")).as("Check assumption about java.util.Properties keys").isTrue();
+    assertThat(javaUtilProperties.containsKey("cr")).as("Check assumption about java.util.Properties keys").isTrue();
+    assertThat(javaUtilProperties.containsKey("crlf_both_escaped")).as("Check assumption about java.util.Properties keys").isTrue();
+    assertThat(javaUtilProperties.containsKey("crlf_only_first_escaped")).as("Check assumption about java.util.Properties keys").isTrue();
+    assertThat(javaUtilProperties.getProperty("lf")).as("Check assumption about java.util.Properties values").isEqualTo("OneTwo");
+    assertThat(javaUtilProperties.getProperty("cr")).as("Check assumption about java.util.Properties values").isEqualTo("OneTwo");
+    assertThat(javaUtilProperties.getProperty("crlf_both_escaped")).as("Check assumption about java.util.Properties values").isEqualTo("OneTwo");
+    assertThat(javaUtilProperties.getProperty("crlf_only_first_escaped")).as("Check assumption about java.util.Properties values").isEqualTo("OneTwo");
 
     // - execution
-    final List<String> readEntries= new ArrayList<>();
+    final List<Entry> readEntries= new ArrayList<>();
     try (final PropertyFileReader reader= new PropertyFileReader(propertyFile);) {
       Entry entry;
       while ((entry= reader.readEntry()) != null) {
-        readEntries.add(entry.toCharSequence().toString());
+        readEntries.add(entry);
       }
     }
 
     // - validation
-    assertThat(readEntries.size()).isEqualTo(13);
+    assertThat(readEntries.size()).isEqualTo(javaUtilProperties.size());
     assertThat(readEntries.get(0)).isEqualTo("keyA1=valueA1\n");
     assertThat(readEntries.get(1)).isEqualTo(" keyA2  =  valueA2\n");
     assertThat(readEntries.get(2)).isEqualTo("\tkeyA3\t=\tvalue A3\t\n");

--- a/src/test/java/de/poiu/apron/io/PropertyFileReaderTest.java
+++ b/src/test/java/de/poiu/apron/io/PropertyFileReaderTest.java
@@ -18,8 +18,6 @@ package de.poiu.apron.io;
 import de.poiu.apron.entry.BasicEntry;
 import de.poiu.apron.entry.Entry;
 import de.poiu.apron.entry.PropertyEntry;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -27,6 +25,7 @@ import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/de/poiu/apron/io/PropertyFileReaderTest.java
+++ b/src/test/java/de/poiu/apron/io/PropertyFileReaderTest.java
@@ -437,6 +437,12 @@ public class PropertyFileReaderTest {
       + "cr                       = One\\\rTwo\r"
       + "crlf_both_escaped        = One\\\r\\\nTwo\r\n"
       + "crlf_only_first_escaped  = One\\\r\nTwo\r\n");
+
+    final Properties javaUtilProperties= new Properties();
+    try (final FileInputStream fis= new FileInputStream(propertyFile);) {
+      javaUtilProperties.load(fis);
+    }
+
     // assert our assumptions about the java.util.Properties implementation
     assertThat(javaUtilProperties.size()).as("Check assumption about java.util.Properties size").isEqualTo(4);
     assertThat(javaUtilProperties.containsKey("lf")).as("Check assumption about java.util.Properties keys").isTrue();
@@ -459,26 +465,10 @@ public class PropertyFileReaderTest {
 
     // - validation
     assertThat(readEntries.size()).isEqualTo(javaUtilProperties.size());
-    assertThat(readEntries.get(0)).isEqualTo("keyA1=valueA1\n");
-    assertThat(readEntries.get(1)).isEqualTo(" keyA2  =  valueA2\n");
-    assertThat(readEntries.get(2)).isEqualTo("\tkeyA3\t=\tvalue A3\t\n");
-    assertThat(readEntries.get(3)).isEqualTo("keyA4 = very long\\\r\n" +
-        "value A4 over \\\r\n" +
-        "multiple lines\r\n");
-    assertThat(readEntries.get(4)).isEqualTo("        \n");
-    assertThat(readEntries.get(5)).isEqualTo("keyB1:valueB1\n");
-    assertThat(readEntries.get(6)).isEqualTo(" keyB2 : valueB2\n");
-    assertThat(readEntries.get(7)).isEqualTo("\t keyB3\t:\t value B3 \n");
-    assertThat(readEntries.get(8)).isEqualTo("keyB4 : very long\\\n" +
-        "value B4 over \\\n" +
-        "multiple lines\\\n" +
-        "\n");
-    assertThat(readEntries.get(9)).isEqualTo("keyC1 valueC1\n");
-    assertThat(readEntries.get(10)).isEqualTo("  keyC2   valueC2\n");
-    assertThat(readEntries.get(11)).isEqualTo("\t keyC3\t\tvalue C3 \n");
-    assertThat(readEntries.get(12)).isEqualTo("keyC4   very long\\\n" +
-        "value C4 over \\\n" +
-        "\t \tmultiple lines\n");
+    assertThat(readEntries.get(0)).isEqualTo(new PropertyEntry("", "lf", "                       = ", "One\\\nTwo", "\n"));
+    assertThat(readEntries.get(1)).isEqualTo(new PropertyEntry("", "cr", "                       = ", "One\\\rTwo", "\r"));
+    assertThat(readEntries.get(2)).isEqualTo(new PropertyEntry("", "crlf_both_escaped", "        = ", "One\\\r\\\nTwo", "\r\n"));
+    assertThat(readEntries.get(3)).isEqualTo(new PropertyEntry("", "crlf_only_first_escaped", "  = ", "One\\\r\nTwo", "\r\n"));
   }
 
   private File createTestFile(final String content) {


### PR DESCRIPTION
The current implementation of `PropertyFileReader` does not parse logical lines correctly in case the physical line contains \\r\n line ending characters. The backslash is read, the \r is treated as escaped, but then the \n character is read in the next loop interation and is treated as a new line. I modified an existing testcase to show this. I propose the following fix to `PropertyFileReader` parsing loop. 